### PR TITLE
Add Makefile targets and logic to make a redhat RPM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+redhat/BUILD*
+redhat/RPMS
+redhat/SRPMS
+redhat/SPECS
+redhat/SOURCES
+*.tar.xz
+*~

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,36 @@
+NAME	:= starvation_monitor
+VERSION	:= 0.1
+
+
 INSTALL=install
-CFLAGS ?= -Wall
+CFLAGS ?= -Wall -O2 -g
+
+DIRS	:=	src redhat
+FILES 	:=	Makefile README.md
+TARBALL	:=	$(NAME)-$(VERSION).tar.xz
 
 all: src/starvation_monitor.o
 	$(CC) -o starvation_monitor -ggdb -lpthread src/starvation_monitor.o
 
 .PHONY: install
 install:
+	$(INSTALL) -m 755 -d $(DESTDIR)/usr/bin $(DESTDIR)/usr/share/$(NAME)-$(VERSION)
 	$(INSTALL) starvation_monitor -m 755 $(DESTDIR)/usr/bin/
+	$(INSTALL) README.md -m 644 $(DESTDIR)/usr/share/$(NAME)-$(VERSION)
 
-.PHONY: clean
+.PHONY: clean tarball
 clean:
 	@test ! -f starvation_monitor || rm starvation_monitor
 	@test ! -f src/starvation_monitor.o || rm src/starvation_monitor.o
+	@test ! -f $(TARBALL) || rm -f $(TARBALL)
+	@make -C redhat clean
+	@rm -rf *~
+
+tarball:  clean
+	rm -rf $(NAME)-$(VERSION) && mkdir $(NAME)-$(VERSION)
+	cp -r $(DIRS) $(FILES) $(NAME)-$(VERSION)
+	tar -cvJf $(TARBALL) --exclude='*~' $(NAME)-$(VERSION)
+	rm -rf $(NAME)-$(VERSION)
+
+redhat: tarball
+	$(MAKE) -C redhat

--- a/redhat/Makefile
+++ b/redhat/Makefile
@@ -1,0 +1,25 @@
+# Red Hat specific Makefile
+
+HERE	:= $(shell pwd)
+RPMDIRS	:= SPECS SOURCES BUILDROOT RPMS SRPMS BUILD
+RPMARGS	:= 	--define "_topdir	$(HERE)" \
+		--define "_sourcedir	$(HERE)/SOURCES" \
+		--define "_builddir 	$(HERE)/BUILD" \
+		--define "_rpmdir	$(HERE)/RPMS" \
+		--define "_srcrpmdir	$(HERE)/SRPMS"
+
+all: rpm
+
+rpmdirs:
+	@[ -d SPECS ]	|| mkdir SPECS
+	@[ -d SOURCES ]	|| mkdir SOURCES
+	@[ -d BUILD ]	|| mkdir BUILD
+	@[ -d RPMS ]	|| mkdir RPMS
+	@[ -d SRPMS ]	|| mkdir SRPMS
+
+rpm: rpmdirs
+	cp ../*.tar.xz SOURCES
+	rpmbuild -ba $(RPMARGS) starvation_monitor.spec
+
+clean:
+	@rm -rf $(RPMDIRS) *~

--- a/redhat/starvation_monitor.spec
+++ b/redhat/starvation_monitor.spec
@@ -1,0 +1,39 @@
+Name:		starvation_monitor
+Version:	0.1
+Release:	1%{?dist}
+Summary:	daemon that finds starving tasks and gives them a temporary boost
+
+License:	GPL
+URL:		https://github.com/bristot/starvation_monitor
+Source0:	%{name}-%{version}.tar.xz
+
+BuildRequires: glibc-devel
+Requires:      systemd
+
+%description
+The starvation_monitor program monitors the set of system threads, looking for threads
+that are ready-to-run but have not been given cpu time for some threshold period. When
+a starving thread is found, it is given a temporary boost using the SCHED_DEADLINE
+policy. The default is to allow 10 microseconds of runtime for 1 second of clock time.
+
+%prep
+%autosetup
+
+
+%build
+%make_build
+
+
+%install
+rm -rf $RPM_BUILD_ROOT
+%make_install
+
+
+%files
+/usr/bin/%{name}
+%doc /usr/share/%{name}-%{version}/README.md
+
+
+%changelog
+* Wed Aug 19 2020 williams@redhat.com
+-


### PR DESCRIPTION
Modified the Makefile to include a version, then added a subdirectory
named redhat with a Makefile and specfile for building an rpm.

Signed-off-by: Clark Williams <williams@redhat.com>